### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 MCP Server for the Slack API, enabling Claude to interact with Slack workspaces as a user.
 
+<a href="https://glama.ai/mcp/servers/wc0u5519qh"><img width="380" height="200" src="https://glama.ai/mcp/servers/wc0u5519qh/badge" alt="Slack User Server MCP server" /></a>
+
 ## Tools
 
 1. `slack_list_channels`


### PR DESCRIPTION
This PR adds a badge for the [Slack User MCP Server](https://glama.ai/mcp/servers/wc0u5519qh) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/wc0u5519qh"><img width="380" height="200" src="https://glama.ai/mcp/servers/wc0u5519qh/badge" alt="Slack User Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.